### PR TITLE
Adaptions to nuclear/etex inversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output
 miniconda3
 from_nebula
 input_data/**/*.nc
+**/__pycache__/**

--- a/AshInv/AshInversion.py
+++ b/AshInv/AshInversion.py
@@ -489,7 +489,7 @@ class AshInversion():
                             #new_size = 1
                             #while new_size < row_width:
                             #    new_size = new_size << 1
-                            new_size = int(row_width*1.1) #Increase to 10% more than actual row width
+                            new_size = max(row_width+1, int(row_width*1.1)) #Increase to 10% more than actual row width
                             self.logger.info("Row width too large, resizing Q_c from {:d} to {:d} columns".format(Q_c.shape[1], new_size))
                             Q_c = np.zeros((Q_c.shape[0], new_size))
                             

--- a/AshInv/AshInversion.py
+++ b/AshInv/AshInversion.py
@@ -137,7 +137,7 @@ class AshInversion():
         Read the a priori emission estimates from file
         and make the a priori vectors
 
-        param: a_priori_file - CSV-file with dates and filenames for satellite observations
+        param: a_priori_file - JSON-file with dates and filenames for a_priori
 
         scale_a_priori - Scale a_priori to same unit as emission/observation (typically kg => kg is 1)
         min_emission_uncertainty_scale - Set minimum uncertainty to average multiplied by scale

--- a/AshInv/AshInversion.py
+++ b/AshInv/AshInversion.py
@@ -371,7 +371,7 @@ class AshInversion():
                     obs = nc_file['obs'][:]
                     n_obs = len(obs)
 
-                    obs_flag = nc_file['obs_flag'][:]
+                    # obs_flag = nc_file['obs_flag'][:]
 
                     if (use_elevations):
                         obs_alt = nc_file['obs_alt'][:]*1000 #FIXME: Given in KM

--- a/AshInv/Plot.py
+++ b/AshInv/Plot.py
@@ -237,8 +237,14 @@ def plotEmissions(json_data,
         # hardcoded units
         if unit == 'g/s':
             sum *= 3600 / (1000)
-            sum_unit = "kg"            
-        plt.plot(x_vals, dataset[0], label=f'Sum: {sum:.0f} {unit}')
+            sum_unit = "kg"
+        elif unit == 'PBq/h':
+            sum_unit = 'PBq'
+        elif unit == 'Bq/s': # ruthenium
+            sum_unit = 'TBq'
+            sum *= 3600 * 1.e-12
+
+        plt.plot(x_vals, dataset[0], label=f'Sum: {sum:.0f} {sum_unit}')
         plt.xticks(rotation=40)
         plt.legend()
 
@@ -295,6 +301,10 @@ def plotAshInv(json_data,
 
         unit_scale = 1.0/(json_data['level_heights'][:,None]*duration)*1.0e9
     elif (unit == 'g/s'): # etex
+        unit_scale = 1.0
+    elif unit == 'PBq/h': # loviisa
+        unit_scale = 1.0
+    elif unit == 'Bq/s': # loviisa
         unit_scale = 1.0
     else:
         raise "Unknown unit {:s}".format(unit)

--- a/AshInv/Plot.py
+++ b/AshInv/Plot.py
@@ -240,6 +240,9 @@ def plotEmissions(json_data,
             sum_unit = "kg"
         elif unit == 'PBq/h':
             sum_unit = 'PBq'
+        elif unit == 'Bq/h':
+            sum_unit = 'PBq'
+            sum *= 1.e-15
         elif unit == 'Bq/s': # ruthenium
             sum_unit = 'TBq'
             sum *= 3600 * 1.e-12
@@ -304,7 +307,9 @@ def plotAshInv(json_data,
         unit_scale = 1.0
     elif unit == 'PBq/h': # loviisa
         unit_scale = 1.0
-    elif unit == 'Bq/s': # loviisa
+    elif unit == 'Bq/h': # loviisa2
+        unit_scale = 1.0
+    elif unit == 'Bq/s': # ruth
         unit_scale = 1.0
     else:
         raise "Unknown unit {:s}".format(unit)

--- a/ash_inv.yml
+++ b/ash_inv.yml
@@ -2,7 +2,7 @@ name:
   - ash_inversion_env
 channels:
   - defaults
-  - anaconda
+  - conda-forge
 dependencies:
   - json5=0.8.5
   - matplotlib=3.3.4

--- a/bin/inversion_job_script.sh
+++ b/bin/inversion_job_script.sh
@@ -50,6 +50,7 @@ RUN_INVERSION=${RUN_INVERSION:-0}
 RUN_PLOTS=${RUN_PLOTS:-0}
 RUN_A_POSTERIORI_CSV=${RUN_A_POSTERIORI_CSV:-0}
 SOLVER=${SOLVER:-"direct"}
+UNITS=${UNITS:-"Tg"}
 RUN_DATE=${RUN_DATE:-$(date +"%Y%m%dT%H%MZ")}
 RESULTS_DIR=${RESULTS_DIR:-"$RUN_DIR/results/${TAG}_${RUN_DATE}"}
 SYSTEM_MATRIX_FILE=${SYSTEM_MATRIX_FILE:-"$RUN_DIR/inversion_system_matrix.npz"}
@@ -259,7 +260,8 @@ if [ $RUN_PLOTS == 1 ]; then
                         --colormap birthe \
                         --usetex=False \
                         --json $RESULT_JSON \
-                        --output $RESULT_PNG
+                        --output $RESULT_PNG \
+                        --unit $UNITS
     done
 fi
 

--- a/bin/inversion_job_script.sh
+++ b/bin/inversion_job_script.sh
@@ -36,7 +36,9 @@ if [[ -z "$INVERSION_ENVIRONMENT_SETUP" ]]; then
     exit -1
 fi
 
-
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# need to run from script-dir to allow for git
+cd $SCRIPT_DIR
 
 
 
@@ -168,6 +170,7 @@ if [ $RUN_SETUP == 1 ]; then
 
     #Print git version info for reproducibility
     inv_exec echo "INFO: Running git to store source code version and local changes"
+    inv_exec echo $(pwd)
     inv_exec git log -n1
     inv_exec git status --porcelain
     inv_exec echo "INFO: Storing uncommited git changes in patch file '$RESULTS_DIR/uncommitted_changes.patch'"


### PR DESCRIPTION
The code was no longer working with anaconda due to no longer existing packages, but requires conda-forge now

When extending the Q_c matrix, in cases with only very few elements it was increased to a too small size.

Using the ash-inversion code for inversion of nuclear accidents plots with new units where needed.